### PR TITLE
Change default security group api to network

### DIFF
--- a/lib/yao/resources/security_group.rb
+++ b/lib/yao/resources/security_group.rb
@@ -12,9 +12,9 @@ module Yao::Resources
       end)
     end
 
-    self.service        = "compute"
-    self.resource_name  = "os-security-group"
-    self.resources_name = "os-security-groups"
+    self.service        = "network"
+    self.resource_name  = "security-group"
+    self.resources_name = "security-groups"
   end
 end
 

--- a/lib/yao/resources/security_group_rule.rb
+++ b/lib/yao/resources/security_group_rule.rb
@@ -48,8 +48,8 @@ module Yao::Resources
       )
     end
 
-    self.service        = "compute"
-    self.resource_name  = "os-security-group-rule"
-    self.resources_name = "os-security-group-rules"
+    self.service        = "network"
+    self.resource_name  = "security-group-rule"
+    self.resources_name = "security-group-rules"
   end
 end


### PR DESCRIPTION
Compute  api returns 400 bad request when IP address(not CIDR) added.

e.g.
```
$ nova secgroup-list
ERROR (BadRequest): Invalid cidr 8.8.8.8. (HTTP 400) (Request-ID: req-a8b7fbf6-de16-4302-9d1a-903a9b5e4013)

$ neutron security-group-list
+--------------------------------------+---------------+----------------+
| id                                   | name          | description    |
+--------------------------------------+---------------+----------------+
| cf1de535-3173-4160-84f6-41f5c3b782ba | default       | default        |
+--------------------------------------+---------------+----------------+
```